### PR TITLE
Fix script building error for requirejs-config.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ RequireJsResolverPlugin.prototype.getConfig = function(fs) {
         }
 
         var sandbox = {
+            window: {location: {href: ''}},
             paths: {},
             require: function() {
             },


### PR DESCRIPTION
When requirejs-config.js contains window "gulp script" command gets error "ReferenceError: window is not defined". Fix it.