### PR TITLE
Allow injecting variables into requirejs-config sandbox

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const vm = require('vm');
 
 function RequireJsResolverPlugin(options) {
     this.configPath = options.configPath;
+    this.sandbox = options.sandbox || {};
 }
 
 RequireJsResolverPlugin.prototype.getConfig = function(fs) {
@@ -24,11 +25,11 @@ RequireJsResolverPlugin.prototype.getConfig = function(fs) {
             return this.configData;
         }
 
-        var sandbox = {
+        let sandbox = Object.assign({
             paths: {},
             require: function() {
             },
-        };
+        }, this.sandbox);
         sandbox.require.addPaths = function(paths) {
             for (var path in paths) {
                 sandbox.paths[path] = paths[path];

--- a/index.js
+++ b/index.js
@@ -65,7 +65,9 @@ RequireJsResolverPlugin.prototype.apply = function(resolver) {
             } else {
                 callback();
             }
-        })
+        }, err => {
+            callback(err);
+        });
     });
 };
 


### PR DESCRIPTION
This adds a configuration option to inject parameters into the sandbox, in case the requirejs-config.js file refers to external variables.

It also fixes some error handling that made this issue harder to discover in some node.js versions.

Alternative to #1.